### PR TITLE
Specify calling convention of Gtk PInvoke call

### DIFF
--- a/Eto.Gl.Gtk2/GLDrawingArea.cs
+++ b/Eto.Gl.Gtk2/GLDrawingArea.cs
@@ -387,7 +387,7 @@ namespace Eto.Gl.Gtk
 			return XGetVisualInfoInternal (display, (IntPtr)(int)vinfo_mask, ref template, out nitems);
 		}
 
-		[SuppressUnmanagedCodeSecurity, DllImport (libgdk_name)]
+		[SuppressUnmanagedCodeSecurity, DllImport (libgdk_name, CallingConvention = CallingConvention.Cdecl)]
 		public static extern IntPtr gdk_win32_drawable_get_handle (IntPtr d);
 
 		[SuppressUnmanagedCodeSecurity, DllImport (linux_libx11_name)]


### PR DESCRIPTION
I've been working on a small Eto project recently, using this GL control as a way of learning OpenGL, and I've run into a small issue: the Gtk2 version, when run under a Gtk# installation on my Windows 10 machine, crashes in Visual Studio with a PInvokeStackImbalance error. Whether using the control in my own code, or just running the Gtk2 version of TestEtoGl from this repository, the program crashes a few moments after starting.

Some googling led me to an enlightening bug report for another Gtk#/OpenGL project: https://sourceforge.net/p/glwidget/bugs/3/ Turns out it's a simple fix, just specify the calling convention for the PInvoke call. The default in Windows is Stdcall, where Gtk uses Cdecl. Without setting this, using Eto.Gl.Gtk2 in Windows will prevent the stack from being cleaned up.

I've tested this commit on the aforementioned Windows 10 machine, as well as my usual Ubuntu 14.04 Virtualbox VM, and everything seems to be in order, my project and your test project alike.
