### PR TITLE
WPF with WindowsFormsHost

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,0 +1,9 @@
+The following authors have all licensed their contributions to etoViewport
+under the licensing terms detailed in LICENSE.
+
+(Authors keep copyright of their contributions, of course; they just grant
+a license to everyone to use it as detailed in LICENSE.)
+
+* Phil Stopford
+* James Gregory <james@james.id.au>
+

--- a/Eto.Gl.WPF_WinformsHost/Eto.Gl.WPF_WinformsHost.csproj
+++ b/Eto.Gl.WPF_WinformsHost/Eto.Gl.WPF_WinformsHost.csproj
@@ -57,6 +57,7 @@
       <HintPath>..\packages\Eto.Platform.Windows.2.3.0\lib\net45\Eto.WinForms.dll</HintPath>
     </Reference>
     <Reference Include="WindowsBase" />
+    <Reference Include="WindowsFormsIntegration" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Eto.Gl\Eto.Gl.csproj">
@@ -69,9 +70,6 @@
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="..\Eto.Gl.WPF_Renderer\Renderer.cs">
-      <Link>Renderer.cs</Link>
-    </Compile>
     <Compile Include="OtkWpfWFControl.cs" />
     <Compile Include="OtkWpfWFSurfaceHandler.cs" />
   </ItemGroup>

--- a/Eto.Gl.WPF_WinformsHost/OtkWpfWFControl.cs
+++ b/Eto.Gl.WPF_WinformsHost/OtkWpfWFControl.cs
@@ -10,40 +10,44 @@ using OpenTK.Platform;
 using OpenTK.Graphics;
 using OpenTK.Graphics.OpenGL;
 using OpenTK;
-using OpenGLviaFramebuffer;
+using System.Windows.Forms;
+using System.Windows.Forms.Integration;
 
 namespace Eto.Gl.WPF_WFControl
 {
-	public class OtkWpfWFControl : UserControl
+	public class OtkWpfWFControl : System.Windows.Controls.UserControl
 	{
 		private GLControl glControl;
 
-		private Renderer renderer;
+        private WindowsFormsHost wfHost;
 
-		public OtkWpfWFControl()
-		{
-			System.Drawing.Size t = new System.Drawing.Size(this.GetSize().Width, this.GetSize().Height);
-			this.renderer = new Renderer(t);
-
+        public OtkWpfWFControl(GraphicsMode mode, int major, int minor, GraphicsContextFlags flags)
+        {
 			glControl = new GLControl();
-			glControl.Paint += GLcontrolOnPaint;
-		}
+            glControl.Dock = DockStyle.Fill;
+            // XXX: Should we add a glControl.Paint that invokes OnDraw()? Have not done for now, since OnDraw is
+            // already getting called and seems to work -- adding another call would result in double-rendering
+            // everything unless we disable the other callsite.
 
-		public void MakeCurrent()
+            wfHost = new WindowsFormsHost();
+            wfHost.Child = glControl;
+
+            this.AddChild(wfHost);
+        }
+
+        public OtkWpfWFControl(GraphicsMode mode) : this(mode, 1, 0, GraphicsContextFlags.Default)
+        { }
+
+		public OtkWpfWFControl() : this(GraphicsMode.Default)
+		{ }
+
+        public void MakeCurrent()
 		{
 			glControl.MakeCurrent();
 		}
 
 		public void SwapBuffers()
 		{
-			glControl.SwapBuffers();
-		}
-
-		private void GLcontrolOnPaint(object sender, EventArgs e)
-		{
-			glControl.MakeCurrent();
-			GL.LoadIdentity();
-			renderer.Render();
 			glControl.SwapBuffers();
 		}
 	}

--- a/Eto.Gl.WPF_WinformsHost/OtkWpfWFSurfaceHandler.cs
+++ b/Eto.Gl.WPF_WinformsHost/OtkWpfWFSurfaceHandler.cs
@@ -6,7 +6,6 @@ using OpenTK.Graphics;
 using OpenTK.Graphics.OpenGL;
 using System;
 using OpenTK.Graphics.OpenGL;
-using OpenGLviaFramebuffer;
 
 namespace Eto.Gl.WPF_WFControl
 {
@@ -14,7 +13,7 @@ namespace Eto.Gl.WPF_WFControl
 	{
 		public void CreateWithParams(GraphicsMode mode, int major, int minor, GraphicsContextFlags flags)
 		{
-			Control = new OtkWpfWFControl();// mode, major, minor, flags);
+			Control = new OtkWpfWFControl(mode, major, minor, flags);
 		}
 
 		protected override void Initialize()

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,22 @@
+MIT License
+
+Copyright (c) 2016-2017 etoViewport authors, see AUTHORS file.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+

--- a/TestEtoGl.XamMac/MainForm.cs
+++ b/TestEtoGl.XamMac/MainForm.cs
@@ -65,8 +65,11 @@ namespace TestEtoGl
 
 		private void configureProgressBar_(Int32 maxValue)
 		{
-			progressBar.MaxValue = maxValue;
-			progressBar.Value = 0;
+            Application.Instance.Invoke(() =>
+            {
+                progressBar.MaxValue = maxValue;
+                progressBar.Value = 0;
+            });
 		}
 
 		private void updatePreview(object sender, EventArgs e)


### PR DESCRIPTION
Adds support for WPF by using the GLControl inside a WindowsFormsHost. Have also added LICENSE and AUTHORS files so as to explicitly grant a license to use these changes.