### PR TITLE
Don't try to paint viewport if it's not initialized.

### DIFF
--- a/Eto.Gl.WinForms/WinGLSurfaceHandler.cs
+++ b/Eto.Gl.WinForms/WinGLSurfaceHandler.cs
@@ -36,20 +36,22 @@ namespace Eto.Gl.Windows
             Control.SwapBuffers();
         }
 
-		public void updateViewHandler(object sender, EventArgs e)
-		{
-			updateView();
-		}
+        public void updateViewHandler(object sender, EventArgs e)
+        {
+            updateView();
+        }
 
-		public void updateView()
-		{
-			MakeCurrent();
-			GL.Viewport(Control.Size);
-			Callback.OnDraw(Widget, EventArgs.Empty);
-			SwapBuffers();
-		}
+        public void updateView() {
+            if (!Control.IsInitialized)
+                return;
 
-		public override void AttachEvent(string id)
+            MakeCurrent();
+            GL.Viewport(Control.Size);
+            Callback.OnDraw(Widget, EventArgs.Empty);
+            SwapBuffers();
+        }
+
+        public override void AttachEvent(string id)
         {
             switch (id)
             {


### PR DESCRIPTION
I was getting exceptions because the window was trying to render the viewport before it was initialized. This seems to fix it.