### PR TITLE
Fix using GLSurface in a child layout.

### DIFF
--- a/Eto.Gl.Mac/MacGLSurfaceHandler.cs
+++ b/Eto.Gl.Mac/MacGLSurfaceHandler.cs
@@ -61,6 +61,12 @@ namespace Eto.Gl.XamMac
 			set { Control.CanFocus = value; }
 		}
 
+		public override void OnLoadComplete(EventArgs e)
+		{
+			base.OnLoadComplete(e);
+			Control.Initialize();
+		}
+
 		public override void AttachEvent (string id)
         {
             switch (id) {

--- a/Eto.Gl.Mac/MacGLView8.cs
+++ b/Eto.Gl.Mac/MacGLView8.cs
@@ -23,6 +23,7 @@ namespace Eto.Gl.XamMac
 		int major;
 		int minor;
 		GraphicsContextFlags flags;
+		bool canInit;
 
 		public event EventHandler Initialized;
 
@@ -78,16 +79,21 @@ namespace Eto.Gl.XamMac
 			base.ViewDidMoveToWindow();
 			UpdateContext();
 		}
-
+		
 		public override void SetFrameSize(CGSize newSize)
 		{
 			base.SetFrameSize(newSize);
 			UpdateContext();
 		}
 
-		public void InitGL()
+		public void Initialize()
 		{
-			if (IsInitialized || Window == null)
+			canInit = true;
+		}
+
+		void InitGL()
+		{
+			if (IsInitialized || Window == null || !canInit)
 				return;
 
 			windowInfo = Utilities.CreateMacOSWindowInfo(Window.Handle, Handle);


### PR DESCRIPTION
For example, if you put the view in a TableLayout inside another TableLayout.

This makes it so the view can only be initialized when the control is fully loaded.

Fixes #13 

Note there's a few extra changes in MacGLView8.cs due to line endings being inconsistent in the file (some were LF, some CRLF).    Add ?w=1 to the GitHub url to view without whitespace changes.