### PR TITLE
Wire up mouse/keyboard events for WPF.

### DIFF
--- a/Eto.Gl.Gtk2/Eto.Gl.Gtk2.csproj
+++ b/Eto.Gl.Gtk2/Eto.Gl.Gtk2.csproj
@@ -37,11 +37,11 @@
     <Compile Include="GtkGlSurfaceHandler.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="Eto, Version=2.3.6476.4505, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Eto.Forms.2.4.0-build1138\lib\net45\Eto.dll</HintPath>
+    <Reference Include="Eto, Version=2.3.6561.30214, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Eto.Forms.2.4.0-build1193\lib\net45\Eto.dll</HintPath>
     </Reference>
-    <Reference Include="Eto.Gtk2, Version=2.3.6476.4513, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Eto.Platform.Gtk.2.4.0-build1138\lib\net45\Eto.Gtk2.dll</HintPath>
+    <Reference Include="Eto.Gtk2, Version=2.3.6561.30219, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Eto.Platform.Gtk.2.4.0-build1193\lib\net45\Eto.Gtk2.dll</HintPath>
     </Reference>
     <Reference Include="Mono.Cairo">
       <HintPath>..\packages\other\GtkSharp\2.12\lib\Mono.Cairo\Mono.Cairo.dll</HintPath>

--- a/Eto.Gl.Gtk2/packages.config
+++ b/Eto.Gl.Gtk2/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Eto.Forms" version="2.4.0-build1138" targetFramework="net45" />
-  <package id="Eto.Platform.Gtk" version="2.4.0-build1138" targetFramework="net45" />
+  <package id="Eto.Forms" version="2.4.0-build1193" targetFramework="net45" />
+  <package id="Eto.Platform.Gtk" version="2.4.0-build1193" targetFramework="net45" />
   <package id="OpenTK" version="3.0.0-pre" targetFramework="net45" />
 </packages>

--- a/Eto.Gl.Mac/Eto.Gl.Mac.csproj
+++ b/Eto.Gl.Mac/Eto.Gl.Mac.csproj
@@ -33,14 +33,14 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Eto, Version=2.3.6476.4505, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Eto.Forms.2.4.0-build1138\lib\net45\Eto.dll</HintPath>
+    <Reference Include="Eto, Version=2.3.6561.30214, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Eto.Forms.2.4.0-build1193\lib\net45\Eto.dll</HintPath>
     </Reference>
-    <Reference Include="Eto.Mac, Version=2.3.6476.4513, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Eto.Platform.Mac.2.4.0-build1138\lib\net45\Eto.Mac.dll</HintPath>
+    <Reference Include="Eto.Mac, Version=2.3.6561.30219, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Eto.Platform.Mac.2.4.0-build1193\lib\net45\Eto.Mac.dll</HintPath>
     </Reference>
     <Reference Include="MonoMac, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Eto.Platform.Mac.2.4.0-build1138\lib\net45\MonoMac.dll</HintPath>
+      <HintPath>..\packages\Eto.Platform.Mac.2.4.0-build1193\lib\net45\MonoMac.dll</HintPath>
     </Reference>
     <Reference Include="OpenTK, Version=3.0.0.0, Culture=neutral, PublicKeyToken=bad199fe84eb3df4, processorArchitecture=MSIL">
       <HintPath>..\packages\OpenTK.3.0.0-pre\lib\net20\OpenTK.dll</HintPath>

--- a/Eto.Gl.Mac/packages.config
+++ b/Eto.Gl.Mac/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Eto.Forms" version="2.4.0-build1138" targetFramework="net45" />
-  <package id="Eto.Platform.Mac" version="2.4.0-build1138" targetFramework="net45" />
+  <package id="Eto.Forms" version="2.4.0-build1193" targetFramework="net45" />
+  <package id="Eto.Platform.Mac" version="2.4.0-build1193" targetFramework="net45" />
   <package id="OpenTK" version="3.0.0-pre" targetFramework="net45" />
 </packages>

--- a/Eto.Gl.WPF_WinformsHost/Eto.Gl.WPF_WinformsHost.csproj
+++ b/Eto.Gl.WPF_WinformsHost/Eto.Gl.WPF_WinformsHost.csproj
@@ -33,14 +33,14 @@
   </PropertyGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>
-    <Reference Include="Eto, Version=2.3.6476.4505, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Eto.Forms.2.4.0-build1138\lib\net45\Eto.dll</HintPath>
+    <Reference Include="Eto, Version=2.3.6561.30214, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Eto.Forms.2.4.0-build1193\lib\net45\Eto.dll</HintPath>
     </Reference>
-    <Reference Include="Eto.WinForms, Version=2.3.6476.4512, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Eto.Platform.Windows.2.4.0-build1138\lib\net45\Eto.WinForms.dll</HintPath>
+    <Reference Include="Eto.WinForms, Version=2.3.6561.30218, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Eto.Platform.Windows.2.4.0-build1193\lib\net45\Eto.WinForms.dll</HintPath>
     </Reference>
-    <Reference Include="Eto.Wpf, Version=2.3.6476.4522, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Eto.Platform.Wpf.2.4.0-build1138\lib\net45\Eto.Wpf.dll</HintPath>
+    <Reference Include="Eto.Wpf, Version=2.3.6561.30222, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Eto.Platform.Wpf.2.4.0-build1193\lib\net45\Eto.Wpf.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="OpenTK, Version=3.0.0.0, Culture=neutral, PublicKeyToken=bad199fe84eb3df4, processorArchitecture=MSIL">

--- a/Eto.Gl.WPF_WinformsHost/OtkWpfWFControl.cs
+++ b/Eto.Gl.WPF_WinformsHost/OtkWpfWFControl.cs
@@ -1,10 +1,8 @@
-﻿using System;
-using System.ComponentModel;
+﻿using System.ComponentModel;
 using System.Diagnostics;
 using System.Windows;
 using Eto.Wpf;
 using System.Windows.Controls;
-using System.Windows.Media;
 using System.Windows.Media.Imaging;
 using OpenTK.Platform;
 using OpenTK.Graphics;
@@ -15,24 +13,21 @@ using System.Windows.Forms.Integration;
 
 namespace Eto.Gl.WPF_WFControl
 {
-	public class OtkWpfWFControl : System.Windows.Controls.UserControl
+
+
+	public class OtkWpfWFControl : WindowsFormsHost
 	{
 		public GLControl glControl;
-
-        private WindowsFormsHost wfHost;
 
         public OtkWpfWFControl(GraphicsMode mode, int major, int minor, GraphicsContextFlags flags)
         {
 			glControl = new GLControl();
             glControl.Dock = DockStyle.Fill;
-            // XXX: Should we add a glControl.Paint that invokes OnDraw()? Have not done for now, since OnDraw is
-            // already getting called and seems to work -- adding another call would result in double-rendering
-            // everything unless we disable the other callsite.
+			// XXX: Should we add a glControl.Paint that invokes OnDraw()? Have not done for now, since OnDraw is
+			// already getting called and seems to work -- adding another call would result in double-rendering
+			// everything unless we disable the other callsite.
 
-            wfHost = new WindowsFormsHost();
-            wfHost.Child = glControl;
-
-            this.AddChild(wfHost);
+			Child = glControl;
         }
 
         public OtkWpfWFControl(GraphicsMode mode) : this(mode, 1, 0, GraphicsContextFlags.Default)

--- a/Eto.Gl.WPF_WinformsHost/OtkWpfWFSurfaceHandler.cs
+++ b/Eto.Gl.WPF_WinformsHost/OtkWpfWFSurfaceHandler.cs
@@ -8,11 +8,12 @@ using System;
 
 namespace Eto.Gl.WPF_WFControl
 {
-	public class WPFWFGLSurfaceHandler : WpfControl<OtkWpfWFControl, GLSurface, GLSurface.ICallback>, GLSurface.IHandler
+	public class WPFWFGLSurfaceHandler : WindowsFormsHostHandler<GLControl, GLSurface, GLSurface.ICallback>, GLSurface.IHandler
 	{
 		public void CreateWithParams(GraphicsMode mode, int major, int minor, GraphicsContextFlags flags)
 		{
-			Control = new OtkWpfWFControl(mode, major, minor, flags);
+			WinFormsControl = new GLControl(mode, major, minor, flags);
+			Control.Focusable = true;
 		}
 
 		protected override void Initialize()
@@ -21,32 +22,23 @@ namespace Eto.Gl.WPF_WFControl
 			HandleEvent(GLSurface.GLDrawEvent);
 		}
 
-		public bool IsInitialized
+		public bool IsInitialized => Control.IsInitialized;
+
+		public void MakeCurrent() => WinFormsControl.MakeCurrent();
+
+		public void SwapBuffers() => WinFormsControl.SwapBuffers();
+
+		public void UpdateWpfHandler(object sender, EventArgs e)
 		{
-			get { return Control.IsInitialized; }
+			UpdateWpf();
 		}
 
-		public void MakeCurrent()
+		public void UpdateWpf()
 		{
-			Control.MakeCurrent();
-		}
-
-		public void SwapBuffers()
-		{
-			Control.SwapBuffers();
-		}
-
-		public void updateWPFHandler(object sender, EventArgs e)
-		{
-			updateWPF();
-		}
-
-		public void updateWPF()
-		{
-			Control.glControl.MakeCurrent();
-			GL.Viewport(Control.glControl.ClientSize);
+			MakeCurrent();
+			GL.Viewport(WinFormsControl.ClientSize);
 			Callback.OnDraw(Widget, EventArgs.Empty);
-			Control.glControl.SwapBuffers();
+			SwapBuffers();
 		}
 
 		public override void AttachEvent(string id)
@@ -64,7 +56,7 @@ namespace Eto.Gl.WPF_WFControl
 				case GLSurface.ShownEvent:
 				case GLSurface.SizeChangedEvent:
 				case GLSurface.GLDrawEvent:
-					Control.glControl.Paint += updateWPFHandler;
+					WinFormsControl.Paint += UpdateWpfHandler;
 					break;
 
 				default:

--- a/Eto.Gl.WPF_WinformsHost/packages.config
+++ b/Eto.Gl.WPF_WinformsHost/packages.config
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Eto.Forms" version="2.4.0-build1138" targetFramework="net45" />
-  <package id="Eto.Platform.Windows" version="2.4.0-build1138" targetFramework="net45" />
-  <package id="Eto.Platform.Wpf" version="2.4.0-build1138" targetFramework="net45" />
+  <package id="Eto.Forms" version="2.4.0-build1193" targetFramework="net45" />
+  <package id="Eto.Platform.Windows" version="2.4.0-build1193" targetFramework="net45" />
+  <package id="Eto.Platform.Wpf" version="2.4.0-build1193" targetFramework="net45" />
   <package id="OpenTK" version="3.0.0-pre" targetFramework="net45" />
   <package id="OpenTK.GLControl" version="3.0.0-pre" targetFramework="net45" />
 </packages>

--- a/Eto.Gl.WinForms/Eto.Gl.WinForms.csproj
+++ b/Eto.Gl.WinForms/Eto.Gl.WinForms.csproj
@@ -48,11 +48,11 @@
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="Eto, Version=2.3.6476.4505, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Eto.Forms.2.4.0-build1138\lib\net45\Eto.dll</HintPath>
+    <Reference Include="Eto, Version=2.3.6561.30214, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Eto.Forms.2.4.0-build1193\lib\net45\Eto.dll</HintPath>
     </Reference>
-    <Reference Include="Eto.WinForms, Version=2.3.6476.4512, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Eto.Platform.Windows.2.4.0-build1138\lib\net45\Eto.WinForms.dll</HintPath>
+    <Reference Include="Eto.WinForms, Version=2.3.6561.30218, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Eto.Platform.Windows.2.4.0-build1193\lib\net45\Eto.WinForms.dll</HintPath>
     </Reference>
     <Reference Include="OpenTK, Version=3.0.0.0, Culture=neutral, PublicKeyToken=bad199fe84eb3df4, processorArchitecture=MSIL">
       <HintPath>..\packages\OpenTK.3.0.0-pre\lib\net20\OpenTK.dll</HintPath>

--- a/Eto.Gl.WinForms/packages.config
+++ b/Eto.Gl.WinForms/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Eto.Forms" version="2.4.0-build1138" targetFramework="net45" />
-  <package id="Eto.Platform.Windows" version="2.4.0-build1138" targetFramework="net45" />
+  <package id="Eto.Forms" version="2.4.0-build1193" targetFramework="net45" />
+  <package id="Eto.Platform.Windows" version="2.4.0-build1193" targetFramework="net45" />
   <package id="OpenTK" version="3.0.0-pre" targetFramework="net45" />
 </packages>

--- a/Eto.Gl/Eto.Gl.csproj
+++ b/Eto.Gl/Eto.Gl.csproj
@@ -32,8 +32,8 @@
     <ConsolePause>false</ConsolePause>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Eto, Version=2.3.6476.4505, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Eto.Forms.2.4.0-build1138\lib\net45\Eto.dll</HintPath>
+    <Reference Include="Eto, Version=2.3.6561.30214, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Eto.Forms.2.4.0-build1193\lib\net45\Eto.dll</HintPath>
     </Reference>
     <Reference Include="OpenTK, Version=3.0.0.0, Culture=neutral, PublicKeyToken=bad199fe84eb3df4, processorArchitecture=MSIL">
       <HintPath>..\packages\OpenTK.3.0.0-pre\lib\net20\OpenTK.dll</HintPath>

--- a/Eto.Gl/packages.config
+++ b/Eto.Gl/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Eto.Forms" version="2.4.0-build1138" targetFramework="net45" />
+  <package id="Eto.Forms" version="2.4.0-build1193" targetFramework="net45" />
   <package id="OpenTK" version="3.0.0-pre" targetFramework="net45" />
 </packages>

--- a/TestEtoGl.Gtk2/TestEtoGl.Gtk2.csproj
+++ b/TestEtoGl.Gtk2/TestEtoGl.Gtk2.csproj
@@ -29,11 +29,11 @@
     <ConsolePause>false</ConsolePause>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Eto, Version=2.3.6476.4505, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Eto.Forms.2.4.0-build1138\lib\net45\Eto.dll</HintPath>
+    <Reference Include="Eto, Version=2.3.6561.30214, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Eto.Forms.2.4.0-build1193\lib\net45\Eto.dll</HintPath>
     </Reference>
-    <Reference Include="Eto.Gtk2, Version=2.3.6476.4513, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Eto.Platform.Gtk.2.4.0-build1138\lib\net45\Eto.Gtk2.dll</HintPath>
+    <Reference Include="Eto.Gtk2, Version=2.3.6561.30219, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Eto.Platform.Gtk.2.4.0-build1193\lib\net45\Eto.Gtk2.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="atk-sharp, Version=2.12.0.0, Culture=neutral, PublicKeyToken=35e10195dab3c99f">

--- a/TestEtoGl.Gtk2/packages.config
+++ b/TestEtoGl.Gtk2/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Eto.Forms" version="2.4.0-build1138" targetFramework="net45" />
-  <package id="Eto.Platform.Gtk" version="2.4.0-build1138" targetFramework="net45" />
+  <package id="Eto.Forms" version="2.4.0-build1193" targetFramework="net45" />
+  <package id="Eto.Platform.Gtk" version="2.4.0-build1193" targetFramework="net45" />
 </packages>

--- a/TestEtoGl.WPF_WinformsHost/TestEtoGl.WPF_WinformsHost.csproj
+++ b/TestEtoGl.WPF_WinformsHost/TestEtoGl.WPF_WinformsHost.csproj
@@ -32,11 +32,11 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Eto, Version=2.3.6476.4505, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Eto.Forms.2.4.0-build1138\lib\net45\Eto.dll</HintPath>
+    <Reference Include="Eto, Version=2.3.6561.30214, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Eto.Forms.2.4.0-build1193\lib\net45\Eto.dll</HintPath>
     </Reference>
-    <Reference Include="Eto.Wpf, Version=2.3.6476.4522, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Eto.Platform.Wpf.2.4.0-build1138\lib\net45\Eto.Wpf.dll</HintPath>
+    <Reference Include="Eto.Wpf, Version=2.3.6561.30222, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Eto.Platform.Wpf.2.4.0-build1193\lib\net45\Eto.Wpf.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/TestEtoGl.WPF_WinformsHost/packages.config
+++ b/TestEtoGl.WPF_WinformsHost/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Eto.Forms" version="2.4.0-build1138" targetFramework="net45" />
-  <package id="Eto.Platform.Wpf" version="2.4.0-build1138" targetFramework="net45" />
+  <package id="Eto.Forms" version="2.4.0-build1193" targetFramework="net45" />
+  <package id="Eto.Platform.Wpf" version="2.4.0-build1193" targetFramework="net45" />
 </packages>

--- a/TestEtoGl.WinForms/TestEtoGl.WinForms.csproj
+++ b/TestEtoGl.WinForms/TestEtoGl.WinForms.csproj
@@ -32,11 +32,11 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Eto, Version=2.3.6476.4505, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Eto.Forms.2.4.0-build1138\lib\net45\Eto.dll</HintPath>
+    <Reference Include="Eto, Version=2.3.6561.30214, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Eto.Forms.2.4.0-build1193\lib\net45\Eto.dll</HintPath>
     </Reference>
-    <Reference Include="Eto.WinForms, Version=2.3.6476.4512, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Eto.Platform.Windows.2.4.0-build1138\lib\net45\Eto.WinForms.dll</HintPath>
+    <Reference Include="Eto.WinForms, Version=2.3.6561.30218, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Eto.Platform.Windows.2.4.0-build1193\lib\net45\Eto.WinForms.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/TestEtoGl.WinForms/packages.config
+++ b/TestEtoGl.WinForms/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Eto.Forms" version="2.4.0-build1138" targetFramework="net45" />
-  <package id="Eto.Platform.Windows" version="2.4.0-build1138" targetFramework="net45" />
+  <package id="Eto.Forms" version="2.4.0-build1193" targetFramework="net45" />
+  <package id="Eto.Platform.Windows" version="2.4.0-build1193" targetFramework="net45" />
 </packages>

--- a/TestEtoGl/TestEtoGl.csproj
+++ b/TestEtoGl/TestEtoGl.csproj
@@ -31,8 +31,8 @@
     <ConsolePause>false</ConsolePause>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Eto, Version=2.3.6476.4505, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Eto.Forms.2.4.0-build1138\lib\net45\Eto.dll</HintPath>
+    <Reference Include="Eto, Version=2.3.6561.30214, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Eto.Forms.2.4.0-build1193\lib\net45\Eto.dll</HintPath>
     </Reference>
     <Reference Include="LibTessDotNet, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Unofficial.LibTessDotNet.1.0.2\lib\net45\LibTessDotNet.dll</HintPath>

--- a/TestEtoGl/packages.config
+++ b/TestEtoGl/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Eto.Forms" version="2.4.0-build1138" targetFramework="net45" />
+  <package id="Eto.Forms" version="2.4.0-build1193" targetFramework="net45" />
   <package id="OpenTK" version="3.0.0-pre" targetFramework="net45" />
   <package id="Unofficial.LibTessDotNet" version="1.0.2" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
Updates Eto to build 1193 to use new WindowsFormsHostHandler.

This should fix wiring up the mouse and keyboard events.  I implemented the wireup in Eto.Wpf using WindowsFormsHostHandler so we can reuse the key/mouse event mappings already created in Eto.WinForms.  It will also help hookup other winforms controls when used in WPF.

I haven't looked at the sizing issues mentioned in #8 yet, but resizing the viewport seems to work for me.