### PR TITLE
Fix license detection

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-MIT License
+The MIT License
 
 Copyright (c) 2016-2017 etoViewport authors, see AUTHORS file.
 


### PR DESCRIPTION
Github required the extra "The" to recognize the license, so this pull request simply adds the "The".