### PR TITLE
Prevent SDL2 from being detected on Mac.

### DIFF
--- a/Eto.Gl.Mac/MacGLSurfaceHandler.cs
+++ b/Eto.Gl.Mac/MacGLSurfaceHandler.cs
@@ -20,7 +20,10 @@ namespace Eto.Gl.XamMac
 	{
 		static MacGLSurfaceHandler()
 		{
-			Toolkit.Init();
+			Toolkit.Init(new ToolkitOptions
+			{
+				Backend = PlatformBackend.PreferNative // prevent SDL2 from being detected if it is installed.
+			});
 		}
 
 		protected override void Initialize()


### PR DESCRIPTION
With homebrew (and probably other ways) you can install SDL2 so that it gets detected by OpenTK.  This prevents SDL2 from being detected on Mac, which caused the GraphicsContext from being created with this exception:

```
OpenTK.Graphics.GraphicsContextException: The specified window isn't an OpenGL window
  at OpenTK.Platform.SDL2.Sdl2GraphicsContext..ctor (OpenTK.Graphics.GraphicsMode mode, OpenTK.Platform.IWindowInfo win, OpenTK.Graphics.IGraphicsContext shareContext, System.Int32 major, System.Int32 minor, OpenTK.Graphics.GraphicsContextFlags flags) [0x00075] in /home/jarl/Programming/opentk-3.0/src/OpenTK/Platform/SDL2/Sdl2GraphicsContext.cs:81 
  at OpenTK.Platform.SDL2.Sdl2Factory.CreateGLContext (OpenTK.Graphics.GraphicsMode mode, OpenTK.Platform.IWindowInfo window, OpenTK.Graphics.IGraphicsContext shareContext, System.Boolean directRendering, System.Int32 major, System.Int32 minor, OpenTK.Graphics.GraphicsContextFlags flags) [0x00000] in /home/jarl/Programming/opentk-3.0/src/OpenTK/Platform/SDL2/Sdl2Factory.cs:66 
  at OpenTK.Graphics.GraphicsContext..ctor (OpenTK.Graphics.GraphicsMode mode, OpenTK.Platform.IWindowInfo window, OpenTK.Graphics.IGraphicsContext shareContext, System.Int32 major, System.Int32 minor, OpenTK.Graphics.GraphicsContextFlags flags) [0x000c0] in /home/jarl/Programming/opentk-3.0/src/OpenTK/Graphics/GraphicsContext.cs:184 
  at OpenTK.Graphics.GraphicsContext..ctor (OpenTK.Graphics.GraphicsMode mode, OpenTK.Platform.IWindowInfo window, System.Int32 major, System.Int32 minor, OpenTK.Graphics.GraphicsContextFlags flags) [0x00000] in /home/jarl/Programming/opentk-3.0/src/OpenTK/Graphics/GraphicsContext.cs:89 
  at Eto.Gl.Mac.MacGLView8.InitGL () [0x0003f] in /Users/curtis/Projects/External/etoViewport/Eto.Gl.Mac/MacGLView8.cs:111 
  at Eto.Gl.Mac.MacGLView8.DrawRect (MonoMac.CoreGraphics.CGRect dirtyRect) [0x0000e] in /Users/curtis/Projects/External/etoViewport/Eto.Gl.Mac/MacGLView8.cs:60 
  at (wrapper dynamic-method) System.Object.[Eto.Gl.Mac.MacGLView8:Void DrawRect(MonoMac.CoreGraphics.CGRect)](MonoMac.Foundation.NSObject,intptr,MonoMac.CoreGraphics.CGRect)
  at (wrapper native-to-managed) System.Object.[Eto.Gl.Mac.MacGLView8:Void DrawRect(MonoMac.CoreGraphics.CGRect)](MonoMac.Foundation.NSObject,intptr,MonoMac.CoreGraphics.CGRect)
  at (wrapper managed-to-native) MonoMac.AppKit.NSApplication.NSApplicationMain(int,string[])
  at MonoMac.AppKit.NSApplication.Main (System.String[] args) [0x00036] in <12e22787720449cc9edb2ad93613d089>:0 
  at Eto.Mac.Forms.ApplicationHandler.Run () [0x00047] in <bf6a6d580b704f00b44cbe7f80f21866>:0 
  at Eto.Forms.Application.Run (Eto.Forms.Form mainForm) [0x0002c] in <7a4d7548471747c8b0ee7bd806e6f93f>:0 
  at TestEtoGl.Mac.Program.Main (System.String[] args) [0x0002d] in /Users/curtis/Projects/External/etoViewport/TestEtoGl.Mac/Program.cs:19 
```