### PR TITLE
Wpf/WinForms: Fix initial draw of viewport in some cases.

### DIFF
--- a/Eto.OpenTK.WinForms/WinGLUserControl.cs
+++ b/Eto.OpenTK.WinForms/WinGLUserControl.cs
@@ -217,11 +217,12 @@ namespace Eto.OpenTK.WinForms
         protected override void OnPaint(PaintEventArgs e)
         {
             EnsureValidHandle();
+            if (context != null)
+            {
+                context.Update(windowInfo);
+            }
 
             base.OnPaint(e);
-
-            // prompt view to update when it is repainted
-            OnResize(EventArgs.Empty);
         }
 
         /// <summary>

--- a/Eto.OpenTK.Wpf/WpfWinGLSurfaceHandler.cs
+++ b/Eto.OpenTK.Wpf/WpfWinGLSurfaceHandler.cs
@@ -17,6 +17,8 @@ namespace Eto.OpenTK.Wpf
         public void CreateWithParams(GraphicsMode mode, int major, int minor, GraphicsContextFlags flags)
         {
             WinFormsControl = new WinGLUserControl(mode, major, minor, flags);
+            Control.Focusable = true;
+            Control.Background = System.Windows.SystemColors.ControlBrush;
         }
 
         protected override void Initialize()
@@ -25,29 +27,15 @@ namespace Eto.OpenTK.Wpf
             HandleEvent(GLSurface.GLDrawEvent);
         }
 
-        public bool IsInitialized
-        {
-            get { return Control.IsInitialized; }
-        }
+        public bool IsInitialized => WinFormsControl.IsInitialized;
 
-        public void MakeCurrent()
-        {
-            WinFormsControl.MakeCurrent();
-        }
+        public void MakeCurrent() => WinFormsControl.MakeCurrent();
 
-        public void SwapBuffers()
-        {
-            WinFormsControl.SwapBuffers();
-        }
+        public void SwapBuffers() => WinFormsControl.SwapBuffers();
 
-        public void updateViewHandler(object sender, EventArgs e)
+        public void UpdateView()
         {
-            updateView();
-        }
-
-        public void updateView()
-        {
-            if (!Control.IsInitialized)
+            if (!WinFormsControl.IsInitialized)
                 return;
 
             MakeCurrent();
@@ -68,12 +56,8 @@ namespace Eto.OpenTK.Wpf
                     WinFormsControl.ShuttingDown += (sender, e) => Callback.OnShuttingDown(Widget, e);
                     break;
 
-                case GLSurface.ShownEvent:
-                case GLSurface.SizeChangedEvent:
                 case GLSurface.GLDrawEvent:
-                    WinFormsControl.SizeChanged += updateViewHandler;
-                    WinFormsControl.Paint += updateViewHandler;
-                    //Control.Resize += (sender, e) => Callback.OnDraw(Widget, EventArgs.Empty);
+                    WinFormsControl.Paint += (sender, e) => UpdateView();
                     break;
 
                 default:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,9 +1,8 @@
-﻿variables:
+variables:
   solution: 'Eto.OpenTK.sln'
-  build.version: '0.1.0-ci-$(Build.BuildNumber)'
+  build.version: '0.1.2-ci-$(Build.BuildNumber)'
   build.configuration: 'Release'
   build.arguments: /restore /t:Build;Pack /p:BuildVersion=$(build.version) /p:BuildBranch=$(Build.SourceBranch)
-  
 
 trigger:
   - master


### PR DESCRIPTION
- Only subscribe to Paint to update the view (like before)
- Don't override Eto's Control.Shown or SizeChanged event registration, it caused the view to be redrawn many multiple times (and broke those events).
- Update the context during OnPaint() instead of calling OnResize to do the same as it has unintended side effects e.g. causes the view not to show initially.
- Set the background of the WPF control to ControlBrush so it doesn't show unpainted areas when resizing.