### PR TITLE
Mac: Fix issue with mouse move event not firing with latest Eto.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,17 @@
+# EditorConfig is awesome: http://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+# use tabs by default for everything
+[*.cs]
+indent_style = tab
+indent_size = 4
+tab_size = 4
+charset=utf-8
+csharp_new_line_before_open_brace = all
+
+[*.{csproj,vbproj,proj,targets,props}]
+indent_style = space
+indent_size = 2
+tab_size = 2

--- a/Eto.OpenTK.Mac/MacGLSurfaceHandler.cs
+++ b/Eto.OpenTK.Mac/MacGLSurfaceHandler.cs
@@ -18,7 +18,7 @@ using AppKit;
 namespace Eto.OpenTK.Mac
 {
 
-    public class MacGLSurfaceHandler : MacView<MacGLView8, GLSurface, GLSurface.ICallback>, GLSurface.IHandler
+	public class MacGLSurfaceHandler : MacView<MacGLView8, GLSurface, GLSurface.ICallback>, GLSurface.IHandler
 	{
 		static MacGLSurfaceHandler()
 		{
@@ -101,7 +101,11 @@ namespace Eto.OpenTK.Mac
 					break;
 
 				case Eto.Forms.Control.SizeChangedEvent:
-					Control.SizeChanged += (sender, e) => Callback.OnSizeChanged(Widget, EventArgs.Empty);
+					Control.SizeChanged += (sender, e) =>
+					{
+						OnSizeChanged(EventArgs.Empty);
+						Callback.OnSizeChanged(Widget, EventArgs.Empty);
+					};
 					break;
 
 				default:


### PR DESCRIPTION
It wasn't updating the mouse tracking areas when the control is resized.  This was a problem before but only when resizing the viewport after initially shown.